### PR TITLE
Update BigQuery locations

### DIFF
--- a/google/resource_bigquery_dataset.go
+++ b/google/resource_bigquery_dataset.go
@@ -72,7 +72,7 @@ func resourceBigQueryDataset() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "US",
-				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-northeast1", "europe-west2", "australia-southeast1"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"US", "EU", "asia-east1", "asia-northeast1", "asia-southeast1", "australia-southeast1", "europe-north1", "europe-west2", "us-east4"}, false),
 			},
 
 			// defaultPartitionExpirationMs: [Optional] The default partition


### PR DESCRIPTION
Terraform GCP-provider does not allow all current BigQuery locations. Added locations available on 2018-12-14 at https://cloud.google.com/bigquery/docs/locations.